### PR TITLE
Add development notice and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Agent Onboarding Guide
+
+Welcome, fellow agent! This repository powers a Jekyll-based personal website. Use this quick tour to get oriented before making changes.
+
+## Start Here
+
+- Read `USAGE.md` for a full walkthrough of the stack, directory layout, and build workflows.
+- Skim `README.md` if you only need the Docker quickstart.
+- Check `ISSUES.md` for known gaps or work-in-progress topics.
+- Planning presentations? Open `PRESENTATIONS.md` for reveal.js conventions.
+
+## Key Site Components
+
+- Configuration: `_config.yml` (primary settings) and `_config.dev.yml` (overrides for local work).
+- Templates: `_layouts/` (page skeletons) and `_includes/` (reusable partials such as `nav.html`, `footer.html`, and `intro.html`).
+- Data-driven content: `_data/` for YAML-backed values (`SocialNetworks.yml`, `ui-text.yml`).
+- Homepage: `index.html` assembles the intro, contact info, and statements via the includes above.
+- Pages & posts: Markdown in the repository root (e.g., `aboutme.md`) or `_posts/` for dated blog entries.
+
+## Local Development
+
+1. Install dependencies with Docker (`docker-compose up`) or the Ruby toolchain (`bundle install` then `bundle exec jekyll serve`).
+2. Serve the site locally at `http://localhost:4000/`.
+3. Restart the server after editing `_config.yml`; most other changes hot-reload.
+
+The `Makefile` wraps common commands (`make install`, `make run`, `make clean`, `make update`).
+
+## Working Effectively
+
+- Keep HTML tidy and prefer includes when you add reusable page fragments.
+- Styles live in `css/` (global) and `css/theme/` (presentation themes). Use the existing structure.
+- Reveal.js assets and plugins sit in `js/`, `lib/`, and `plugin/`; follow the patterns in `talks/` and `course_slides/`.
+- Store new media in `img/` and reference with site-root-relative paths (`/img/...`).
+
+## Before You Ship
+
+- Preview changes locally whenever possible.
+- Lint YAML front matter—one stray space can break a build.
+- Summarize changes in pull requests and note any manual follow-up.
+
+Need more context? Reach out to the maintainer or check the Beautiful Jekyll docs: <https://github.com/daattali/beautiful-jekyll>.

--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@ use-site-title: true
 bigimg: [/img/futuristic-cityscape-at-night_800.jpg, /img/ai-cover.jpg]
 ---
 
+<div class="development-notice">
+  <strong>🚧 Under active development:</strong> We are continuing to improve this site, so content may change frequently.
+</div>
+
 <!-- a mamador quote -->
 <center>
   <h3>


### PR DESCRIPTION
Add a development notice to the homepage and create `AGENTS.md` to guide fellow agents.

---
<a href="https://cursor.com/background-agent?bcId=bc-7447bf86-98f5-4a8b-aa29-988fc16bcb5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7447bf86-98f5-4a8b-aa29-988fc16bcb5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an agent onboarding guide and a development notice banner on the homepage.
> 
> - **Documentation**:
>   - Add `AGENTS.md` onboarding guide outlining project structure, local development, and workflows.
> - **Homepage**:
>   - Insert development notice banner in `index.html` to indicate active site updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60d517dc8d81445d5982e56b0fdbf0ea5394362b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->