### PR TITLE
Investigate missing navigation arrows and standardize UI

### DIFF
--- a/_presentations/hanabi-challenge.html
+++ b/_presentations/hanabi-challenge.html
@@ -1,4 +1,5 @@
 ---
+layout: reveal
 title: "The Hanabi Challenge: A New Frontier for AI Research"
 subtitle: "Bard, Foerster, Chandar, et al."
 presenter: "Albert Orozco Camacho"
@@ -770,5 +771,3 @@ Questions?
 </p>
 </section>
 </section>
-</div>
-</div>


### PR DESCRIPTION
Fix missing navigation arrows and broken presentation layout by adding `layout: reveal` and removing duplicate closing `div` tags.

The presentation was not rendering correctly because Jekyll wasn't applying the `reveal.html` layout due to the missing `layout: reveal` front matter declaration. Additionally, extra `</div>` tags at the end of the file caused HTML structural issues, further breaking the display of navigation elements and other controls.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5c16122-7053-4102-a7f6-4071125a37c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5c16122-7053-4102-a7f6-4071125a37c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

