### PR TITLE
Standardize reveal.js presentations and list links

### DIFF
--- a/_presentations/demoday.html
+++ b/_presentations/demoday.html
@@ -1,0 +1,167 @@
+---
+layout: reveal
+title: "Excavando en las profundidades de la información"
+subtitle: "¡Es la era de la inteligencia artificial!"
+presenter: "Albert Manuel Orozco Camacho"
+reveal:
+  # Core settings
+  theme: simple
+  transition: slide
+  backgroundTransition: fade
+  controls: true
+  progress: true
+  history: true
+  center: true
+  
+  # Menu plugin
+  menu: true
+  menu_config:
+    side: left
+    transitions: true
+    openButton: true
+    
+  # Chalkboard plugin
+  chalkboard: true
+  chalkboard_config:
+    theme: chalkboard
+    toggleChalkboardButton: true
+    toggleNotesButton: true
+  
+  # Math support
+  math: true
+  math_config:
+    mathjax: 'https://cdn.mathjax.org/mathjax/latest/MathJax.js'
+    config: 'TeX-AMS_HTML-full'
+  
+  # Navigation
+  home_link: true
+  home_url: '/'
+  home_label: 'Back to Home'
+  links:
+    - label: 'Centraal Academy'
+      url: 'https://centraal.academy/programs/machine-learning'
+  
+  # Centraal logo
+  logo: '/img/centraal_logo_blanco.png'
+  logo_alt: 'Centraal'
+  
+  # Other plugins
+  markdown: true
+  highlight: true
+  zoom: true
+  notes: true
+---
+
+<section>
+  <section data-menu-title="Portada" data-background-image="/img/network3.gif">
+  </section>
+  <section data-transition="fade">
+    <h1>¡Es la era de la inteligencia artificial!</h1>
+  </section>
+  <section data-background-image="/img/arguments.jpg">
+  </section>
+  <section>
+    <img src="/img/ai-kid-eating.jpeg" width="40%" height="40%" alt="">
+    <img src="/img/her-film.jpg" width="50%" height="50%"  alt="">
+  </section>
+  <section>
+    <img src="/img/types-of-data.png" width="55%" height="55%" alt="" style="border:none;">
+  </section>
+  <section data-background-image="/img/science.png">
+  </section>
+  <section data-background-image="/img/analytics.png">
+  </section>
+  <section data-background-image="/img/trumppopularity.gif">
+  </section>
+  <section>
+    <img src="/img/twitter.png" width="55%" height="55%" alt="" style="border:none;">
+  </section>
+  <section data-background-image="/img/tweets.jpg">
+  </section>
+  <section data-background-image="/img/twitter-users.jpg">
+  </section>
+  <section data-background-image="/img/twitter-users-mobile.png">
+  </section>
+  <section data-background-image="/img/news.jpg">
+  </section>
+  <section>
+    <img src="/img/trump-truth.png" width="40%" height="40%" alt="">
+    <img src="/img/dresser-gere.jpg" width="50%" height="50%"  alt="">
+  </section>
+  <section>
+    <img src="/img/klopp-templo.jpg" width="50%" height="50%"  alt="">
+  </section>
+  <section data-background-image="/img/critcal-thinking.jpg">
+  </section>
+  <section data-background-image="/img/flowcharts.jpg">
+  </section>
+  <section>
+    <img src="/img/turing.jpg" width="40%" height="40%" alt="">
+    <img src="/img/church.jpg" width="40%" height="40%"  alt="">
+  </section>
+  <section>
+    <img src="/img/random-numbers.png" width="33%" height="33%" alt="">
+    <img src="/img/optimization-stats.png" width="43%" height="43%" alt="">
+    <img src="/img/gpu.png" width="33%" height="33%" alt="">
+  </section>
+  <section data-background-image="/img/actuarial.jpg">
+  </section>
+  <section data-background-image="/img/physics.jpg">
+  </section>
+  <section data-transition="fade">
+    <h1>¿Por qué <b>aprendizaje</b>?</h1>
+  </section>
+  <section>
+    <h2>En computación</h2>
+    <p>
+      <ul>
+        <li>modelamos fenómenos <i>computables,</i></li>
+        <li>abstraemos las características más importantes,</li>
+        <li>diseñamos algoritmos,</li>
+        <li>para el <b>entendimiento desde la máquina</b>.</li>
+      </ul>
+    </p>
+  </section>
+  <section data-background-image="/img/brain.jpg">
+  </section>
+  <section>
+    <img src="/img/toddlers.jpg" width="53%" height="53%" alt="">
+    <img src="/img/icub-vs-toddler.jpg" width="43%" height="43%" alt="">
+  </section>
+  <section data-background-image="/img/image-dataset.png">
+  </section>
+  <section data-background-image="/img/clustering.png">
+  </section>
+  <section>
+    <img src="/img/rl.gif" width="53%" height="53%" alt="">
+  </section>
+  <section data-background-image="/img/agent.gif">
+  </section>
+  <section data-background-image="/img/turingtest.jpg">
+  </section>
+  <section data-transition="fade">
+    <h2>Ok, la <i>IA</i> necesita de nuestros datos, pero, ¿qué nos da a cambio?</h2>
+  </section>
+  <section data-background-image="/img/privacy.jpeg">
+  </section>
+  <section>
+    <img src="/img/maps-tracking.jpg" width="43%" height="43%" alt="">
+    <img src="/img/canada-goose.jpg" width="23%" height="23%" alt="">
+    <img src="/img/facebook-graph.jpg" width="33%" height="33%" alt="">
+  </section>
+  <section data-transition="fade">
+    <h2>O, en su defecto...</h2>
+  </section>
+  <section>
+    <img src="/img/pepe-trump.jpg" width="43%" height="43%" alt="">
+    <img src="/img/cambridge-analytica.jpg" width="43%" height="43%" alt="">
+  </section>
+  <section>
+    <a href="https://centraal.academy/programs/machine-learning" target="_blank">
+      <img src="/img/curso-ml-centraal.png" width="53%" height="53%" alt="">
+    </a>
+  </section>
+  <section data-transition="fade">
+    <h2>¡Muchas gracias!</h2>
+  </section>
+</section>

--- a/_presentations/eyes-on-bot.html
+++ b/_presentations/eyes-on-bot.html
@@ -1,0 +1,321 @@
+---
+layout: reveal
+title: "Implementando ojos a tu chatbot"
+subtitle: "Cuando el mundo virtual te vigila..."
+presenter: "Albert Manuel Orozco Camacho"
+reveal:
+  # Core settings
+  theme: custom_white
+  transition: slide
+  backgroundTransition: fade
+  controls: true
+  progress: true
+  history: true
+  center: true
+  
+  # Menu plugin
+  menu: true
+  menu_config:
+    side: left
+    transitions: true
+    openButton: true
+    
+  # Chalkboard plugin
+  chalkboard: true
+  chalkboard_config:
+    theme: chalkboard
+    toggleChalkboardButton: true
+    toggleNotesButton: true
+  
+  # Math support
+  math: true
+  math_config:
+    mathjax: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML'
+    config: 'TeX-AMS_HTML-full'
+  
+  # Navigation
+  home_link: true
+  home_url: '/'
+  home_label: 'Back to Home'
+  
+  # Other plugins
+  markdown: true
+  highlight: true
+  zoom: true
+  notes: true
+---
+
+<section>
+  <section>
+    <h1>Implementando ojos a tu chatbot</h1>
+    <h3>Cuando el mundo virtual te vigila...</h3>
+    <p>
+      <small><a href="http://www.github.com/alorozco53" target="_blank">Albert Manuel Orozco Camacho</a>
+        <br>
+        <a href="http://twitter.com/alorozco53" target="_blank">@alorozco53</a>
+        <br>
+        Facultad de Ciencias - IIMAS, UNAM
+      </small>
+      <br>
+      <img style="border-style: none" width="500" height="250" src="/img/bots_latam.png" alt="2do. Meetup de Bots LATAM">
+    </p>
+  </section>
+
+  <section>
+    <h2>Temas de la charla</h2>
+    <p>
+      <small>
+        <ul>
+          <li>Motivación - problema de reconocimiento de imágenes</li>
+          <li>Aprendizaje automático</li>
+          <li>Aprendizaje profundo</li>
+          <!-- <li> -->
+          <ul>
+            <li>Redes neuronales</li>
+            <li>El perceptrón multicapa</li>
+            <li>Inspiración basada en el ojo humano</li>
+          </ul>
+          <!-- </li> -->
+          <li>Redes neuronales convolucionales</li>
+          <!-- <li> -->
+          <ul>
+            <li>Capas</li>
+            <li>Arquitecturas más populares</li>
+            <li>Puntos de referencia</li>
+          </ul>
+          <!-- </li> -->
+          <li>Código</li>
+        </ul>
+      </small>
+    </p>
+  </section>
+</section>
+
+<section>
+  <section>
+    <h2>¿Cómo es que sabemos que hay un perro en la imagen?</h2>
+    <p>
+      <img src="/img/pip_recog.jpg" width="30%" height="30%" style="border:none;" alt="">
+      <img src="/img/harrison-ford-dog-face.jpeg" width="40%" height="40%" style="border:none;" alt=""><br>
+      <img src="/img/dog_with_hat.png" width="30%" height="30%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <h2>Patrones en imágenes</h2>
+    <p>
+      <img src="/img/bag_of_woman.png" width="40%" height="40%" style="border:none;" alt="">
+      <img src="/img/clusters.png" width="40%" height="40%" style="border:none;" alt=""><br>
+      <img src="/img/findTheQ.png" width="30%" height="30%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <h2>Algunas técnicas básicas</h2>
+    <p>
+      <small>
+        <ul>
+          <li>Comparación de plantillas</li>
+          <li>Modelos estructurales</li>
+          <li>Métodos estadísticos &rarr; $P(info | característica\ de\ imagen)$</li>
+          <li>Modelos de similitud difusos (<i>fuzzy</i>)</li>
+          <li>Clasificador k-NN</li>
+        </ul>
+        <center>$\downarrow$</center>
+        <ul>
+          <li>Un modelo híbrido: <b>Redes neuronales convolucionales</b></li>
+        </ul>
+      </small>
+    </p>
+  </section>
+</section>
+
+<section>
+  <section>
+    <h2>Objetivo de la mayoría del software:</h2>
+    <p>
+      <center>
+        ENTRADA: $\vec{x}$<br>
+        $\downarrow$<br>
+        <font color="red">
+          ALGORITMO: $z = h(\vec{x})$
+        </font><br>
+        $\downarrow$<br>
+        SALIDA: $z$
+      </center>
+    </p>
+    <small>El programador <i>diseña</i> un programa que calcule $z$ en su mente y <i>prueba</i> casos de uso.</small>
+  </section>
+  <section>
+    <h2>Aprendizaje automático</h2>
+    <h3>(Supervisado)</h3>
+    <p>
+      <!-- <small> -->
+      ENTRADA: $\vec{x}$<br>
+      $\downarrow$<br>
+      <font color="red">
+        ALGORITMO: $\hat{z} = h(\vec{x}, \vec{\theta})$
+      </font><br>
+      $\updownarrow \mathcal{D}$<br>
+      <font color="green">
+        Entrenamiento: $J(\vec{\theta}; \vec{x}, \vec{y})$
+      </font><br>
+      $\downarrow$<br>
+      SALIDA: $\hat{z} \approx z$
+      <!-- </small> -->
+    </p>
+    <small>
+      Conjunto de datos: $\mathcal{D}\{(x_1, y_1),\ldots,(x_n, y_n)\}$
+    </small>
+  </section>
+  <section>
+    <h2>Redes neuronales</h2>
+    <p>
+      <figure>
+        <img src="/img/nnzoo.jpg" width="62%" height="62%" style="border:none;" alt="">
+        <figcaption>
+          <small>
+            Tomado de
+            <a src="http://www.asimovinstitute.org/neural-network-zoo/" target="_blank">
+              http://www.asimovinstitute.org/neural-network-zoo/
+            </a>
+          </small>
+        </figcaption>
+      </figure>
+      <img src="/img/neurona" width="30%" height="30%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <h2>Perceptrón multicapa</h2>
+    <p>
+      <img src="/img/perceptron.png" width="55%" height="55%" style="border:none;" alt="">
+      <img src="/img/perceptronSurf.gif" width="42%" height="42%" style="border:none;" alt="">
+    </p>
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Aprendizaje profundo</h2>
+    <h3>(Deep Learning)</h3>
+    <small>
+      <ul>
+        <li>El crecimiento exponencial en la capacidad de cómputo dio pie a un incremento en popularidad de arquitecturas
+          de gran complejidad.</li>
+        <li>La correctud de los modelos profundos dependen (casi) únicamente de la existencia de conjuntos de datos de gran tamaño.</li>
+        <li>Revolución en la manera de resolver problemas:<br>
+          <center><b>¡Algoritmos que aproximan algoritmos mediante métodos de optimización!</b></center></li>
+      </ul>
+    </small>
+  </section>
+  <section>
+    <h2>Modelo de visión humana</h2>
+    <p>
+      <img src="/img/visual_cortex.png" width="62%" height="62%" style="border:none;" alt="">
+      <img src="/img/retina.jpg" width="62%" height="62%" style="border:none;" alt="">
+    </p>
+  </section>
+</section>
+<section>
+  <section>
+    <h3>Redes neuronales convolucionales</h3>
+    <h4>(CNN's, ConvNets)</h4>
+    <p>
+      <small>
+        <ul>
+          <li>Desarrolladas principalmente por Yann LeCun (actual dirección de Facebook AI Research) a finales de los 80's.</li>
+          <li>Una de las principales arguitecturas que <i>explota</i> el poder de la profundidad en redes neuronales.</li>
+          <li>Utiliza combinaciones de cuatro capas: CONV, RELU, POOL y FC=Perceptrón</li>
+        </ul>
+      </small>
+      <img src="/img/convnet.jpeg" width="55%" height="55%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <h2>Capa convolucional</h2>
+    <p>
+      <img src="/img/fCNN.png" width="50%" height="50%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <div class="fig figcenter fighighlight">
+      <iframe src="/talks/material/conv-demo.html" width="100%" height="700px" style="border:none;"></iframe>
+      <div class="figcaption">
+        <!-- <font size="3"> -->
+        <!--   Tomado de <a src="http://cs231n.github.io/convolutional-networks/" target="blank"> -->
+        <!--     http://cs231n.github.io/convolutional-networks/ -->
+        <!--   </a> -->
+        <!-- </font> -->
+      </div>
+    </div>
+  </section>
+  <section>
+    <h2>"Capa" de activación ReLU</h2>
+    <p>
+      <img src="/img/relu.png" width="62%" height="62%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <h2>Capa de reducción de muestreo</h2>
+    <h3>(Pooling)</h3>
+    <p>
+      <img src="/img/pooling.png" width="72%" height="72%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <h3>Arquitectura general</h3>
+    <p>
+      <small>
+        $$INPUT \to [[CONV \to RELU]\{N\} \to POOL?]\{M\} \to [FC \to RELU]\{K\} \to FC$$
+        <ul>
+          <li>$N \leq 3$</li>
+          <li>$M \geq 0$</li>
+          <li>$K \geq 0$</li>
+        </ul>
+      </small><br>
+      <img src="/img/full_cnn.png" width="52%" height="52%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <h2>Algunos modelos famosos</h2>
+    <figure>
+      <img src="/img/vgg16.png" width="50%" height="50%" style="border:none;" alt="">
+      <figcaption>
+        <small>VGG16</small>
+      </figcaption>
+    </figure>
+    <figure>
+      <img src="/img/lenet.png" width="50%" height="50%" style="border:none;" alt="">
+      <figcaption>
+        <small>LeNet</small>
+      </figcaption>
+    </figure>
+  </section>
+  <section>
+    <figure>
+      <img src="/img/alexnet.png" width="60%" height="50%" style="border:none;" alt="">
+      <figcaption>
+        <small>AlexNet</small>
+      </figcaption>
+    </figure>
+    <figure>
+      <img src="/img/inception.png" width="200%" height="50%" style="border:none;" alt="">
+      <figcaption>
+        <small>Inception</small>
+      </figcaption>
+    </figure>
+  </section>
+  <section>
+    <h4>¿Cómo sé que mi modelo haya convergido satisfactoriamente?</h4>
+    <p>
+      <img src="/img/pool5max.jpeg" width="60%" height="70%" style="border:none;" alt="">
+      <img src="/img/occlude.jpeg" width="40%" height="40%" style="border:none;" alt="">
+    </p>
+  </section>
+</section>
+
+<section>
+  <section>
+    <h2>Hands on!!</h2>
+    <p>
+      <img src="/img/meme_mickey.gif" width="50%" height="50%" style="border:none;" alt="">
+    </p>
+  </section>
+</section>

--- a/_presentations/lessons.html
+++ b/_presentations/lessons.html
@@ -1,0 +1,305 @@
+---
+layout: reveal
+title: "Lecciones aprendidas a partir de la generación automática de leyendas para memes de Internet"
+subtitle: "Ponencia para el Meetup 'Platiquemos sobre Inteligencia Artificial'"
+presenter: "Albert Manuel Orozco Camacho"
+reveal:
+  # Core settings
+  theme: white
+  transition: slide
+  backgroundTransition: fade
+  controls: true
+  progress: true
+  history: true
+  center: true
+  
+  # Menu plugin
+  menu: true
+  menu_config:
+    side: left
+    transitions: true
+    openButton: true
+    
+  # Chalkboard plugin
+  chalkboard: true
+  chalkboard_config:
+    theme: chalkboard
+    toggleChalkboardButton: true
+    toggleNotesButton: true
+  
+  # Math support
+  math: true
+  math_config:
+    mathjax: 'https://cdn.mathjax.org/mathjax/latest/MathJax.js'
+    config: 'TeX-AMS_HTML-full'
+  
+  # Navigation
+  home_link: true
+  home_url: '/'
+  home_label: 'Back to Home'
+  
+  # Other plugins
+  markdown: true
+  highlight: true
+  zoom: true
+  notes: true
+---
+
+<section>
+  <section data-menu-title="Hacia la generación automática de leyendas para memes de Internet">
+    <h3>Hacia la generación automática de leyendas para memes de Internet</h3>
+    <p>
+      <small>
+        <a href="http://www.github.com/alorozco53" target="_blank">Albert Manuel Orozco Camacho</a>
+        <br>
+        <a href="http://twitter.com/alorozco53" target="_blank"><i class="fa fa-twitter"></i>@alorozco53</a>
+      </small>
+      <br>
+      <a href="http://www.fciencias.unam.mx" target="_blank">
+        <img width="20%" height="20%" src="/img/ciencias.png" alt="Facultad de Ciencias, UNAM" style="border:none;">
+      </a>
+      <span style="display:inline-block; width: 30mm;"></span>
+      <a href="http://www.mariachi.io" target="_blank">
+        <img width="20%" height="20%" src="/img/logo.jpeg" alt="Mariachi IO" style="border:none;">
+      </a>
+      <span style="display:inline-block; width: 30mm;"></span>
+      <a href="http://www.fractalabogados.com" target="_blank">
+        <img width="30%" height="30%" src="/img/fractal.png" alt="Fractal Abogados" style="border:none;">
+      </a>
+      <br>
+      <img width="25%" height="25%" src="/img/gdgunam.jpeg" alt="GDG UNAM" style="border:none;">
+    </p>
+  </section>
+  <section>
+    <h2>
+      <font face="serif" color="red">LECCIONES APRENDIDAS A PARTIR DE LA</font>
+      generación automática de leyendas para memes de Internet
+    </h2>
+  </section>
+  <section>
+    <img width="80%" height="80%" src="/img/deep_learning_meme_keras.png" alt="DL" style="border:none;">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Motivación</h2>
+  </section>
+  <section data-background-image="/img/server-farm.jpg">
+    <p>
+      <img src="/img/memes-flow.jpg" width="30%" height="30%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <h2>Memética</h2>
+    <p>
+      <img src="/img/dawkins.jpg" width="30%" height="30%" style="border:none;" alt="" class="rotate-25">
+      <span style="display:inline-block; width: 50mm;"></span>
+      <img src="/img/selfish-gene.png" width="30%" height="30%" style="border:none;" alt="" class="rotate25">
+    </p>
+  </section>
+  <section>
+    <h2>¿Trabajo previo? &#x1F914;</h2>
+    <p>
+      <a href="http://www.aclweb.org/old_anthology/N/N15/N15-1039.pdf" target="_blank">
+        <img src="/img/cheezburger.png" width="45%" height="45%" style="border:none;" alt="">
+      </a>
+    </p>
+  </section>
+  <section>
+    <img src="/img/imagenet.jpg" width="35%" height="35%" style="border:none;" alt="">
+    <img src="/img/show_and_tell_ex.png" width="80%" height="80%" style="border:none;" alt="">
+    <figcaption>
+      <small>
+        <a src="https://arxiv.org/pdf/1609.06647.pdf" target="_blank">
+          [Vinyals, <i>et al</i>. 2016]
+        </a>
+      </small>
+    </figcaption>
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Datos</h2>
+  </section>
+  <section data-background-image="/img/memegenerator.png">
+  </section>
+  <section>
+    <img src="/img/sep.png" width="50%" height="50%" style="border:none;" alt="">
+  </section>
+  <section data-background-image="/img/memedisplay.gif">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Aprendizaje profundo</h2>
+    <h3>(Deep Learning)</h3>
+  </section>
+  <section>
+    <img src="/img/deep-learning-book.jpg" width="35%" height="35%" style="border:none;" alt="">
+    <span style="display:inline-block; width: 50mm;"></span>
+    <img src="/img/godeeper.jpg" width="40%" height="40%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Redes neuronales convolucionales</h2>
+    <h3>(CNN's, ConvNets)</h3>
+  </section>
+  <section>
+    <img src="/img/convnet.jpeg" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section data-background-color=rgb(255,255,255)>
+    <div class="fig figcenter fighighlight">
+      <iframe src="/talks/material/conv-demo.html" width="100%" height="700px" style="border:none;">
+      </iframe>
+    </div>
+  </section>
+  <section>
+    <h2>Redes neuronales recurrentes</h2>
+  </section>
+  <section>
+    <img src="/img/perceptron.png" width="82%" height="82%" style="border:none;" alt="">
+  </section>
+  <section data-background-color=rgb(255,255,0)>
+    <img src="/img/rnn-unrolled.png" width="82%" height="82%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h3>Unidad de memoria grande a corto plazo (LSTM)</h3>
+    <img src="/img/lstm.png" width="42%" height="42%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/tsne.png" width="52%" height="52%" style="border:none;" alt="">
+    <img src="/img/vec_ar.png" width="52%" height="52%" style="border:none;" alt=""><br>
+    <center>
+      $V($queen$)\ -\ V($king$)\ \approx V($woman$)\ -\ V($man$)$
+    </center>
+  </section>
+  <section>
+    <img src="/img/manifold.png" width="82%" height="82%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Arquitectura unificada</h2>
+  </section>
+  <section>
+    <img src="/img/show_and_tell.png" width="70%" height="70%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Entrenamiento e inferencia</h2>
+  </section>
+  <section>
+    <img src="/img/rnn0.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn1.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn2.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn3.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn4.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>¿Para qué le sirve una red neuronal a un programador (curioso)?</h2>
+  </section>
+  <section>
+    <h3>Una red convolucional profunda...</h3>
+    <p>
+      <ul>
+        <li>normalmente <b>NO</b> se entrena desde cero;</li>
+        <li>
+          especializa sus primeras capas en tareas <i>genéricas</i>, mientras que su última capa es un <b>POTENTE</b> clasificador lineal;
+        </li>
+        <li>puede <i>reciclar</i> sus pesos para adaptarse a otras tareas.</li>
+      </ul>
+    </p>
+  </section>
+  <section>
+    <img src="/img/first-layer.jpeg" width="70%" height="70%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Afinando una CNN</h2>
+  </section>
+  <section>
+    <img src="/img/transfer.png" width="80%" height="80%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Visualización de <i>datasets</i></h2>
+  </section>
+  <section data-background-image="/img/tsne.jpeg">
+  </section>
+  <section>
+    <img src="/img/cnn_embed_full_1k.jpg" width="70%" height="70%" style="border:none;" alt="">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>La red neuronal en acción (beta)</h2>
+  </section>
+  <section>
+    <img src="/img/ex0.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex1.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex2.png" width="65%" height="65%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex4.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex5.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex6.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex7.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+
+  <section>
+    <h2>Trabajo futuro</h2>
+    <p>
+      <ul>
+        <li>Refinamiento del modelo de lenguaje con técnicas de detección y creación de humor/albures.</li>
+        <li>Experimentación con memes de 2017.</li>
+        <li>Agrupamiento semántico de memes (aprendizaje no supervisado).</li>
+      </ul>
+    </p>
+  </section>
+  <section>
+    <img src="/img/skinometer.jpg" width="55%" height="55%" style="border:none;" alt="">
+    <img src="/img/exp-brain.jpg" width="35%" height="35%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Trabajo futuro</h2>
+    <p>
+      <ul>
+        <li>Estudio de la <i>"viralidad"</i> que puede alcanzar la información generada automáticamente.</li>
+        <li>Estudio del fenómeno de la <i>evolución</i> en propagación de información.</li>
+      </ul>
+    </p>
+  </section>
+  <section>
+    <h2>Trabajo futuro</h2>
+    <p>
+      <ul>
+        <li>Generación automática de contenido en redes sociales (por ejemplo, bots en Twitter).</li>
+        <li>Interacción humano-máquina.</li>
+        <li>Agentes conversacionales (chatbots).</li>
+        <center>
+          <img src="/img/trump-clinton.jpg" width="45%" height="45%" style="border:none;" alt="">
+        </center>
+      </ul>
+    </p>
+  </section>
+</section>
+<section>
+  <section>
+    <h2>¡Muchas gracias!</h2>
+    <img src="/img/cookiemonster.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+</section>

--- a/_presentations/onto-memes.html
+++ b/_presentations/onto-memes.html
@@ -1,0 +1,308 @@
+---
+layout: reveal
+title: "Hacia la generación automática de leyendas para memes de Internet"
+subtitle: "Ponencia para el VIII Coloquio de Lingüística Computacional"
+presenter: "Albert Manuel Orozco Camacho, Ivan Vladimir Meza Ruiz"
+reveal:
+  # Core settings
+  theme: night
+  transition: slide
+  backgroundTransition: fade
+  controls: true
+  progress: true
+  history: true
+  center: true
+  
+  # Menu plugin
+  menu: true
+  menu_config:
+    side: left
+    transitions: true
+    openButton: true
+    
+  # Chalkboard plugin
+  chalkboard: true
+  chalkboard_config:
+    theme: chalkboard
+    toggleChalkboardButton: true
+    toggleNotesButton: true
+  
+  # Math support
+  math: true
+  math_config:
+    mathjax: 'https://cdn.mathjax.org/mathjax/latest/MathJax.js'
+    config: 'TeX-AMS_HTML-full'
+  
+  # Navigation
+  home_link: true
+  home_url: '/'
+  home_label: 'Back to Home'
+  
+  # Other plugins
+  markdown: true
+  highlight: true
+  zoom: true
+  notes: true
+---
+
+<section>
+  <section data-menu-title="Hacia la generación automática de leyendas para memes de Internet">
+    <h3>Hacia la generación automática de leyendas para memes de Internet</h3>
+    <p>
+      <small>
+        <a href="http://www.github.com/alorozco53" target="_blank">Albert Manuel Orozco Camacho</a>,
+        <a href="http://turing.iimas.unam.mx/~ivanvladimir/" target="_blank">Ivan Vladimir Meza Ruiz</a>
+        <br>
+        <a href="http://twitter.com/alorozco53" target="_blank">@alorozco53</a>,
+        <a href="http://twitter.com/ivanvladimir" target="_blank">@ivanvladimir</a>
+        <br>
+        Facultad de Ciencias - IIMAS, UNAM
+      </small>
+      <br>
+      <img style="border-style: none" width="350" height="350" src="/img/linguist.jpg" alt="VIII CoLiCo">
+    </p>
+  </section>
+
+</section>
+<section>
+  <section>
+    <h2>Motivación</h2>
+  </section>
+  <section data-background-image="/img/server-farm.jpg">
+    <p>
+      <img src="/img/memes-flow.jpg" width="30%" height="30%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <h2>Memética</h2>
+    <p>
+      <img src="/img/dawkins.jpg" width="30%" height="30%" style="border:none;" alt="" class="rotate-25">
+      <span style="display:inline-block; width: 50mm;"></span>
+      <img src="/img/selfish-gene.png" width="30%" height="30%" style="border:none;" alt="" class="rotate25">
+    </p>
+  </section>
+  <section>
+    <h2>¿Trabajo previo? &#x1F914;</h2>
+    <p>
+      <a href="http://www.aclweb.org/old_anthology/N/N15/N15-1039.pdf" target="_blank">
+        <img src="/img/cheezburger.png" width="45%" height="45%" style="border:none;" alt="">
+      </a>
+    </p>
+  </section>
+  <section>
+    <img src="/img/imagenet.jpg" width="35%" height="35%" style="border:none;" alt="">
+    <img src="/img/show_and_tell_ex.png" width="80%" height="80%" style="border:none;" alt="">
+    <figcaption>
+      <small>
+        <a src="https://arxiv.org/pdf/1609.06647.pdf" target="_blank">
+          [Vinyals, <i>et al</i>. 2016]
+        </a>
+      </small>
+    </figcaption>
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Tecnología de aprendizaje automático</h2>
+  </section>
+  <section>
+    <h2>Objetivo de la mayoría del software:</h2>
+    <p>
+      <center>
+        ENTRADA: $\vec{x}$<br>
+        $\downarrow$<br>
+        <font color="red">
+          ALGORITMO: $z = h(\vec{x})$
+        </font><br>
+        $\downarrow$<br>
+        SALIDA: $z$
+      </center>
+    </p>
+    <small>El programador <i>diseña</i> un programa que calcule $z$ en su mente y <i>prueba</i> casos de uso.</small>
+  </section>
+  <section>
+    <h3>Aprendizaje automático</h3>
+    <h4>(Supervisado)</h4>
+    <p>
+      <!-- <small> -->
+      ENTRADA: $\vec{x}$<br>
+      $\downarrow$<br>
+      <font color="red">
+        ALGORITMO: $z = h(\vec{x}, \vec{\theta})$
+      </font><br>
+      $\updownarrow$<br>
+      <font color="green">
+        Entrenamiento: $J(\vec{\theta}; \vec{x}, \vec{y})$
+      </font><br>
+      $\downarrow$<br>
+      SALIDA: $z$
+      <!-- </small> -->
+    </p>
+    <small>
+      Conjunto de datos: $\mathcal{D} = \{(x_1, y_1),\ldots,(x_n, y_n)\}$
+    </small>
+  </section>
+  <section>
+    <h2>Redes neuronales</h2>
+    <p>
+      <figure>
+        <img src="/img/nnzoo.jpg" width="62%" height="62%" style="border:none;" alt="">
+        <figcaption>
+          <small>
+            Tomado de
+            <a src="http://www.asimovinstitute.org/neural-network-zoo/" target="_blank">
+              http://www.asimovinstitute.org/neural-network-zoo/
+            </a>
+          </small>
+        </figcaption>
+      </figure>
+    </p>
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Datos</h2>
+  </section>
+  <section data-background-image="/img/memegenerator.png">
+  </section>
+  <section data-background-image="/img/memedisplay.gif">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Aprendizaje profundo</h2>
+    <h3>(Deep Learning)</h3>
+  </section>
+  <section>
+    <img src="/img/deep-learning-book.jpg" width="35%" height="35%" style="border:none;" alt="">
+    <span style="display:inline-block; width: 50mm;"></span>
+    <img src="/img/godeeper.jpg" width="40%" height="40%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Redes neuronales convolucionales</h2>
+    <h3>(CNN's, ConvNets)</h3>
+  </section>
+  <section>
+    <img src="/img/convnet.jpeg" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section data-background-color=rgb(255,255,255)>
+    <div class="fig figcenter fighighlight">
+      <iframe src="/talks/material/conv-demo.html" width="100%" height="700px" style="border:none;">
+      </iframe>
+    </div>
+  </section>
+  <section>
+    <h2>Redes neuronales recurrentes</h2>
+    <h3>(para el interés del lingüista)</h3>
+  </section>
+  <section>
+    <img src="/img/perceptron.png" width="82%" height="82%" style="border:none;" alt="">
+  </section>
+  <section data-background-color=rgb(255,255,0)>
+    <img src="/img/rnn-unrolled.png" width="82%" height="82%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h3>Unidad de memoria grande a corto plazo (LSTM)</h3>
+    <img src="/img/lstm.png" width="42%" height="42%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/tsne.png" width="52%" height="52%" style="border:none;" alt="">
+    <img src="/img/vec_ar.png" width="52%" height="52%" style="border:none;" alt=""><br>
+    <center>
+      $V($queen$)\ -\ V($king$)\ \approx V($woman$)\ -\ V($man$)$
+    </center>
+  </section>
+  <section>
+    <img src="/img/manifold.png" width="82%" height="82%" style="border:none;" alt="">
+  </section>
+</section>
+
+
+<section>
+  <section>
+    <h2>Arquitectura unificada</h2>
+  </section>
+  <section>
+    <img src="/img/show_and_tell.png" width="70%" height="70%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Entrenamiento e inferencia</h2>
+  </section>
+  <section>
+    <img src="/img/rnn0.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn1.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn2.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn3.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn4.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>La red neuronal en acción (beta)</h2>
+  </section>
+  <section>
+    <img src="/img/ex0.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex1.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex2.png" width="65%" height="65%" style="border:none;" alt="">
+  </section>
+  <!-- <section> -->
+  <!--   <img src="/img/ex3.png" width="85%" height="85%" style="border:none;" alt=""> -->
+  <!-- </section> -->
+  <section>
+    <img src="/img/ex4.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Trabajo futuro</h2>
+    <p>
+      <ul>
+        <li>Refinamiento del modelo de lenguaje con técnicas de detección y creación de humor/albures.</li>
+        <li>Experimentación con memes de 2017.</li>
+        <li>Agrupamiento semántico de memes (aprendizaje no supervisado).</li>
+      </ul>
+    </p>
+  </section>
+  <section>
+    <img src="/img/skinometer.jpg" width="55%" height="55%" style="border:none;" alt="">
+    <img src="/img/exp-brain.jpg" width="35%" height="35%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Trabajo futuro</h2>
+    <p>
+      <ul>
+        <li>Estudio de la <i>"viralidad"</i> que puede alcanzar la información generada automáticamente.</li>
+        <li>Estudio del fenómeno de la <i>evolución</i> en propagación de información.</li>
+      </ul>
+    </p>
+  </section>
+  <section>
+    <h2>Trabajo futuro</h2>
+    <p>
+      <ul>
+        <li>Generación automática de contenido en redes sociales (por ejemplo, bots en Twitter).</li>
+        <li>Interacción humano-máquina.</li>
+        <li>Agentes conversacionales (chatbots).</li>
+        <center>
+          <img src="/img/trump-clinton.jpg" width="45%" height="45%" style="border:none;" alt="">
+        </center>
+      </ul>
+    </p>
+  </section>
+</section>
+<section>
+  <section>
+    <h2>¡Muchas gracias!</h2>
+    <img src="/img/cookiemonster.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+</section>

--- a/_presentations/thesis.html
+++ b/_presentations/thesis.html
@@ -1,0 +1,387 @@
+---
+layout: reveal
+title: "Generación automática de memes de Internet a través de una red neuronal profunda"
+subtitle: "T E S I S - Licenciado en Ciencias de la Computación"
+presenter: "Albert Manuel Orozco Camacho"
+reveal:
+  # Core settings
+  theme: league
+  transition: slide
+  backgroundTransition: fade
+  controls: true
+  progress: true
+  history: true
+  center: true
+  
+  # Menu plugin
+  menu: true
+  menu_config:
+    side: left
+    transitions: true
+    openButton: true
+    
+  # Chalkboard plugin
+  chalkboard: true
+  chalkboard_config:
+    theme: chalkboard
+    toggleChalkboardButton: true
+    toggleNotesButton: true
+  
+  # Math support
+  math: true
+  math_config:
+    mathjax: 'https://cdn.mathjax.org/mathjax/latest/MathJax.js'
+    config: 'TeX-AMS_HTML-full'
+  
+  # Navigation
+  home_link: true
+  home_url: '/'
+  home_label: 'Back to Home'
+  
+  # Other plugins
+  markdown: true
+  highlight: true
+  zoom: true
+  notes: true
+---
+
+<section>
+  <section data-menu-title="Portada">
+    <h3>Generación automática de memes de Internet a través de una red neuronal profunda</h3>
+    <h4>T      E      S      I      S</h4>
+    <h5>Que para obtener el grado de</h5>
+    <h4>Licenciado en en Ciencias de la Computación</h4>
+    <h5>presenta</h5>
+      <small>
+        <a href="http://www.github.com/alorozco53" target="_blank">Albert Manuel Orozco Camacho</a>,
+        <a href="http://twitter.com/alorozco53" target="_blank">@AlOrozco53</a>,
+        <br>
+        <img src="/img/ciencias.png" width="150" height="150" style="border:none;" alt="">
+        <span style="display:inline-block; width: 50;"></span>
+        <img src="/img/iimas.jpeg" width="150" height="150" style="border:none;" alt="">
+      </small>
+      <br>
+  </section>
+
+</section>
+<section>
+  <section>
+    <h2>Tarea</h2>
+  </section>
+  <section>
+    <img src="/img/one-does-not-simply.png" width="50%" height="50%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/computer_thinking.jpg" width="50%" height="50%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/one-does-not-simply-find-nemo.jpg" width="50%" height="50%" style="border:none;" alt="">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Motivación</h2>
+  </section>
+  <section data-background-image="/img/server-farm.jpg">
+    <p>
+      <img src="/img/memes-flow.jpg" width="30%" height="30%" style="border:none;" alt="">
+    </p>
+  </section>
+  <section>
+    <h2>Memética</h2>
+    <p>
+      <img src="/img/dawkins.jpg" width="30%" height="30%" style="border:none;" alt="" class="rotate-25">
+      <span style="display:inline-block; width: 50mm;"></span>
+      <img src="/img/selfish-gene.png" width="30%" height="30%" style="border:none;" alt="" class="rotate25">
+    </p>
+  </section>
+  <section>
+    <h2>¿Trabajo previo? &#x1F914;</h2>
+    <!-- <p> -->
+    <!--   <a href="http://www.aclweb.org/old_anthology/N/N15/N15-1039.pdf" target="_blank"> -->
+    <!-- <img src="/img/cheezburger.png" width="45%" height="45%" style="border:none;" alt=""> -->
+    <!--   </a> -->
+    <!-- </p> -->
+  </section>
+  <section>
+    <img src="/img/imagenet.jpg" width="35%" height="35%" style="border:none;" alt="">
+    <img src="/img/show_and_tell_ex.png" width="80%" height="80%" style="border:none;" alt="">
+    <figcaption>
+      <small>
+        <a src="https://arxiv.org/pdf/1609.06647.pdf" target="_blank">
+          [Vinyals, <i>et al</i>. 2016]
+        </a>
+      </small>
+    </figcaption>
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Aprendizaje Automático</h2>
+  </section>
+  <section>
+    <h2>Objetivo de la mayoría del software:</h2>
+    <p>
+      <center>
+        ENTRADA: $\vec{x}$<br>
+        $\downarrow$<br>
+        <font color="red">
+          ALGORITMO: $z = h(\vec{x})$
+        </font><br>
+        $\downarrow$<br>
+        SALIDA: $z$
+      </center>
+    </p>
+    <small>El programador <i>diseña</i> un programa que calcule $z$ en su mente y <i>prueba</i> casos de uso.</small>
+  </section>
+  <section>
+    <h3>Aprendizaje automático</h3>
+    <h4>(Supervisado)</h4>
+    <p>
+      <!-- <small> -->
+      ENTRADA: $\vec{x}$<br>
+      $\downarrow$<br>
+      <font color="red">
+        ALGORITMO: $z = h(\vec{x}, \vec{\theta})$
+      </font><br>
+      $\updownarrow$<br>
+      <font color="green">
+        Entrenamiento: $J(\vec{\theta}; \vec{x}, \vec{y})$
+      </font><br>
+      $\downarrow$<br>
+      SALIDA: $z$
+      <!-- </small> -->
+    </p>
+    <small>
+      Conjunto de ejemplos: $\mathcal{D} = \{(x_1, y_1),\ldots,(x_n, y_n)\}$
+    </small>
+  </section>
+  <section>
+    <h2>Redes neuronales</h2>
+    <img src="/img/redneuronalartificial.png" width="70%" height="70%" style="border:none;" alt="">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Aprendizaje profundo</h2>
+    <h3>(Deep Learning)</h3>
+  </section>
+  <section>
+    <img src="/img/godeeper.jpg" width="60%" height="60%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Redes neuronales convolucionales</h2>
+    <h3>(CNN's, ConvNets)</h3>
+  </section>
+  <section>
+    <img src="/img/conv.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/first-layer.jpeg" width="70%" height="70%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Redes neuronales recurrentes</h2>
+  </section>
+  <section>
+    <img src="/img/perceptron.png" width="82%" height="82%" style="border:none;" alt="">
+  </section>
+  <section data-background-color=rgb(255,255,0)>
+    <img src="/img/rnn-unrolled.png" width="82%" height="82%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h3>Unidad de memoria grande a corto plazo (LSTM)</h3>
+    <img src="/img/lstm.png" width="42%" height="42%" style="border:none;" alt="">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Arquitectura unificada</h2>
+  </section>
+  <section>
+    <!-- <img src="/img/show_and_tell.png" width="70%" height="70%" style="border:none;" alt=""> -->
+    <img src="/img/conv.png" width="60%" height="60%" style="border:none;" alt="">
+    $$+$$
+    <img src="/img/unrolled-lstm.png" width="60%" height="60%" style="border:none;" alt="">
+  </section>
+  <!-- <section> -->
+  <!--   <img src="/img/shallow-model.png" width="40%" height="40%" style="border:none;" alt=""> -->
+  <!-- </section> -->
+</section>
+<section>
+  <section>
+    <h2>Datos</h2>
+  </section>
+  <section data-background-image="/img/memegenerator.png">
+  </section>
+  <section>
+    <img src="/img/sep.png" width="50%" height="50%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Entrenamiento e inferencia</h2>
+  </section>
+  <section>
+    <img src="/img/rnn0.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn1.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn2.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn3.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/rnn4.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Experimentos</h2>
+  </section>
+  <section>
+    <img src="/img/res-experimentos.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h3>Dos modelos resultantes de los experimentos...</h3>
+    <p>
+      <ul>
+        <li><b>Modelo A</b>:</li>
+        <ul>
+          <li>Arquitectura convolucional superficial</li>
+        </ul>
+        <li><b>Modelo B</b>:</li>
+        <ul>
+          <li>Arquitectura convolucional <i>Inception V3</i></li>
+          <li>Modelo afinado con las imágenes de memes</li>
+        </ul>
+      </ul>
+  </section>
+  <section>
+    <h2>Evaluación</h2>
+  </section>
+  <section>
+    <h3>¿Qué tanto se parece el texto generado a un modelo de lenguaje natural?</h3>
+    <h4>Perplejidad</h4>
+    $$PP(S) = p(s_1 s_2 \ldots s_n)^{-\frac{1}{n}}$$
+  </section>
+  <section>
+    <h3>"Nuevos" memes</h3>
+    <img src="/img/new1.jpg" width="40%" height="40%" style="border:none;" alt="">
+    <img src="/img/new2.gif" width="40%" height="40%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h3>Memes del conjunto de evaluación</h3>
+    <img src="/img/old1.png" width="40%" height="40%" style="border:none;" alt="">
+    <img src="/img/old2.png" width="40%" height="40%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h3>"No" memes</h3>
+    <img src="/img/no1.jpg" width="40%" height="40%" style="border:none;" alt="">
+    <img src="/img/no2.jpg" width="40%" height="40%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/avgperplexities.png" width="100%" height="100%" style="border:none;" alt="">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>La red neuronal en acción</h2>
+  </section>
+  <section>
+    <img src="/img/ex0.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex1.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex2.png" width="65%" height="65%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex4.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex5.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/ex8.jpg" width="75%" height="75%" style="border:none;" alt="">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Conclusiones</h2>
+  </section>
+  <section>
+    <ul>
+      <li>Se reunió una gran cantidad de memes separados por imagen y leyenda.</li>
+      <li>Se siguió una metodología de <i>aprendizaje profundo</i> para extracción de características en imágenes.</li>
+      <li>Con lo anterior, se entrenó un modelo neuronal capaz de aprender a generar texto a partir de una imagen</li>
+      <li>
+        El éxito de arquitecturas de gran profundidad (para la presente tarea) es <b>proporcional</b> al número
+        de datos que se puedan añadir al entrenamiento.
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h2>Trabajo futuro</h2>
+    <p>
+      <ul>
+        <li>Refinamiento del modelo de lenguaje con técnicas de detección y creación de humor/albures.</li>
+        <li>Experimentación con memes de 2017.</li>
+        <li>Agrupamiento semántico de memes (aprendizaje no supervisado).</li>
+      </ul>
+    </p>
+  </section>
+  <section>
+    <img src="/img/skinometer.jpg" width="55%" height="55%" style="border:none;" alt="">
+    <img src="/img/exp-brain.jpg" width="35%" height="35%" style="border:none;" alt="">
+  </section>
+  <section>
+    <h2>Trabajo futuro</h2>
+    <p>
+      <ul>
+        <li>Estudio de la <i>"viralidad"</i> que puede alcanzar la información generada automáticamente.</li>
+        <li>Estudio del fenómeno de la <i>evolución</i> en propagación de información.</li>
+      </ul>
+    </p>
+  </section>
+  <section>
+    <h2>Trabajo futuro</h2>
+    <p>
+      <ul>
+        <li>Generación automática de contenido en redes sociales (por ejemplo, bots en Twitter).</li>
+        <li>Interacción humano-máquina.</li>
+        <li>Agentes conversacionales (chatbots).</li>
+        <center>
+          <img src="/img/trump-clinton.jpg" width="45%" height="45%" style="border:none;" alt="">
+        </center>
+      </ul>
+    </p>
+  </section>
+</section>
+<section>
+  <section>
+    <h2>¡Muchas gracias!</h2>
+    <img src="/img/cookiemonster.png" width="85%" height="85%" style="border:none;" alt="">
+  </section>
+</section>
+<section>
+  <section>
+    <h2>Anexos</h2>
+  </section>
+  <section data-background-color=rgb(255,255,255)>
+    <div class="fig figcenter fighighlight">
+      <iframe src="/talks/material/conv-demo.html" width="100%" height="700px" style="border:none;">
+      </iframe>
+    </div>
+  </section>
+  <section>
+    <h2>Afinación de una CNN</h2>
+  </section>
+  <section>
+    <img src="/img/transfer.png" width="80%" height="80%" style="border:none;" alt="">
+  </section>
+  <section>
+    <img src="/img/show_and_tell.png" width="70%" height="70%" style="border:none;" alt="">
+  </section>
+</section>

--- a/_presentations/weight-space-learning.html
+++ b/_presentations/weight-space-learning.html
@@ -1,0 +1,362 @@
+---
+layout: reveal
+title: "Weight Space Learning — Navigating the Geometry of Models"
+subtitle: "Seeing Models as Geometry"
+presenter: "GPT-5 Codex"
+reveal:
+  # Core settings
+  theme: night
+  transition: slide
+  backgroundTransition: fade
+  controls: true
+  progress: true
+  history: true
+  center: true
+  
+  # Menu plugin
+  menu: true
+  menu_config:
+    side: left
+    transitions: true
+    openButton: true
+    
+  # Chalkboard plugin
+  chalkboard: true
+  chalkboard_config:
+    theme: chalkboard
+    toggleChalkboardButton: true
+    toggleNotesButton: true
+  
+  # Math support
+  math: true
+  math_config:
+    mathjax: 'https://cdn.mathjax.org/mathjax/latest/MathJax.js'
+    config: 'TeX-AMS_HTML-full'
+  
+  # Navigation
+  home_link: true
+  home_url: '/'
+  home_label: 'Back to Home'
+  links:
+    - label: 'Visualizing Loss Landscapes'
+      url: 'https://arxiv.org/abs/1712.09913'
+    - label: 'Mode Connectivity'
+      url: 'https://arxiv.org/abs/1906.06762'
+    - label: 'Sharpness-Aware Minimization'
+      url: 'https://arxiv.org/abs/2205.03201'
+  
+  # Centraal logo
+  logo: '/img/centraal_logo_blanco.png'
+  logo_alt: 'Centraal'
+  
+  # Other plugins
+  markdown: true
+  highlight: true
+  zoom: true
+  notes: true
+---
+
+<section>
+  <section data-transition="fade" data-background-color="#03040f" data-background-image="/img/network3.gif" data-background-size="cover" data-background-opacity="0.2">
+    <div class="title-card">
+      <h1 data-auto-animate>Weight Space Learning</h1>
+      <h3 data-auto-animate>Seeing Models as Geometry</h3>
+      <p class="attribution">crafted by <strong>GPT-5 Codex</strong>, 2025</p>
+    </div>
+  </section>
+
+  <section data-background-color="#050816">
+    <h2>Why weight space?</h2>
+    <ul>
+      <li class="fragment">Every model parameter vector <em>w</em> is a point in a high-dimensional space.</li>
+      <li class="fragment">Learning traces a path through that space via optimization.</li>
+      <li class="fragment">Geometry reveals <strong>expressivity, robustness,</strong> and <strong>generalization</strong>.</li>
+    </ul>
+    <aside class="notes">
+      Frame the intuition: models are trajectories through weight space informed by data and inductive bias.
+    </aside>
+  </section>
+
+  <section data-background-color="#070b20" data-auto-animate>
+    <h2>Visualizing a slice</h2>
+    <svg viewBox="0 0 600 360" width="70%" data-auto-animate>
+      <defs>
+        <linearGradient id="planeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stop-color="#1b6ca8" stop-opacity="0.8"></stop>
+          <stop offset="100%" stop-color="#102542" stop-opacity="0.9"></stop>
+        </linearGradient>
+      </defs>
+      <rect x="0" y="0" width="600" height="360" fill="#050816"></rect>
+      <g transform="translate(60,40)">
+        <polygon points="0,240 260,210 520,260 260,300" fill="url(#planeGradient)" opacity="0.85"></polygon>
+        <line x1="260" y1="210" x2="260" y2="300" stroke="#5adedc" stroke-width="2" stroke-dasharray="4 6"></line>
+        <circle cx="260" cy="255" r="12" fill="#ffd166"></circle>
+        <text x="270" y="245" fill="#ffd166" font-size="20">w*</text>
+        <line x1="120" y1="235" x2="380" y2="275" stroke="#f25f5c" stroke-width="4" marker-end="url(#arrowHead)"></line>
+        <text x="100" y="225" fill="#f25f5c" font-size="18">loss gradient</text>
+        <text x="0" y="20" fill="#9fb8d1" font-size="22">2D projection of a high-D weight space</text>
+      </g>
+      <defs>
+        <marker id="arrowHead" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+          <polygon points="0,0 8,4 0,8" fill="#f25f5c"></polygon>
+        </marker>
+      </defs>
+    </svg>
+  </section>
+
+  <section data-background-color="#050816" data-auto-animate>
+    <h2>Weight space inhabitants</h2>
+    <div class="grid">
+      <div class="fragment">
+        <h3>Manifold of solutions</h3>
+        <p>Over-parameterized networks admit entire <strong>flat valleys</strong> of low loss.</p>
+      </div>
+      <div class="fragment">
+        <h3>Basins &amp; barriers</h3>
+        <p>Saddle points surround minima; wide basins usually generalize better.</p>
+      </div>
+      <div class="fragment">
+        <h3>Null directions</h3>
+        <p>Symmetries (e.g., neuron permutations) produce equivalent points.</p>
+      </div>
+    </div>
+  </section>
+
+  <section data-background-color="#071323">
+    <h2>Loss landscapes as terrain</h2>
+    <canvas id="loss-landscape" width="760" height="420"></canvas>
+    <p class="fragment fade-in">Gradient descent is a hiker with noisy senses, momentum is a compass.</p>
+  </section>
+
+  <section data-background-color="#030818">
+    <h2>Optimization loop</h2>
+    <svg class="loop-diagram" viewBox="0 0 760 320">
+      <defs>
+        <linearGradient id="loopGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="#54c5f8"></stop>
+          <stop offset="100%" stop-color="#8a5cff"></stop>
+        </linearGradient>
+      </defs>
+      <rect x="0" y="0" width="760" height="320" rx="28" fill="rgba(10, 18, 42, 0.65)"></rect>
+      <g fill="#e6f1ff" font-size="26" font-weight="500">
+        <text x="90" y="140">data batch</text>
+        <text x="320" y="60">forward pass</text>
+        <text x="545" y="140">loss &amp; gradients</text>
+        <text x="305" y="260">parameter update</text>
+      </g>
+      <g stroke="url(#loopGradient)" stroke-width="8" fill="none" stroke-linecap="round">
+        <path d="M140 180 C 220 280, 320 280, 380 240" marker-end="url(#arrowHeadLg)"></path>
+        <path d="M380 240 C 460 200, 480 140, 520 120" marker-end="url(#arrowHeadLg)"></path>
+        <path d="M520 120 C 590 90, 640 70, 640 130" marker-end="url(#arrowHeadLg)"></path>
+        <path d="M640 130 C 640 200, 480 280, 280 120" marker-end="url(#arrowHeadLg)"></path>
+      </g>
+      <defs>
+        <marker id="arrowHeadLg" markerWidth="14" markerHeight="14" refX="7" refY="7" orient="auto">
+          <polygon points="0,0 14,7 0,14" fill="url(#loopGradient)"></polygon>
+        </marker>
+      </defs>
+    </svg>
+    <p class="fragment">Data &rarr; gradient &rarr; update &rarr; new point in weight space</p>
+  </section>
+
+  <section data-background-color="#050816" data-auto-animate>
+    <h2>Regularization reshapes the landscape</h2>
+    <ul>
+      <li class="fragment"><strong>L2</strong> adds spherical walls pulling weights toward the origin.</li>
+      <li class="fragment"><strong>Dropout</strong> forces exploration of wider valleys.</li>
+      <li class="fragment"><strong>Sharpness-aware minimization</strong> explicitly penalizes curvature.</li>
+    </ul>
+  </section>
+
+  <section data-background-color="#071a30" data-auto-animate>
+    <h2>Dimensionality tricks</h2>
+    <div class="columns">
+      <div class="fragment">
+        <h3>Linear mode connectivity</h3>
+        <p>Interpolate between checkpoints to reveal connected minima.</p>
+      </div>
+      <div class="fragment">
+        <h3>Filter outliers</h3>
+        <p>Project onto dominant Hessian eigenvectors to study sharpness.</p>
+      </div>
+      <div class="fragment">
+        <h3>Low-rank adapters</h3>
+        <p>Fine-tune in subspaces without leaving pre-trained basins.</p>
+      </div>
+    </div>
+  </section>
+
+  <section data-background-color="#050816">
+    <h2>Algorithms as trajectories</h2>
+    <pre><code class="language-python">
+def step(params, grad, state):
+    direction = momentum(state, grad)
+    scaled = adapt(direction, state)
+    return project(params - scaled)
+    </code></pre>
+    <p class="fragment">Optimizers differ by how they shape <code>direction</code>, <code>scaled</code>, and <code>project</code>.</p>
+  </section>
+
+  <section data-background-color="#03040f" data-transition="convex">
+    <h2>Designing with weight space intuition</h2>
+    <ul>
+      <li class="fragment">Visual diagnostics (PCA, CCA) expose training dynamics.</li>
+      <li class="fragment">Curriculum learning chooses <em>paths</em>, not just endpoints.</li>
+      <li class="fragment">Hyperparameter sweeps sample the landscape statistically.</li>
+      <li class="fragment">Ensembles average across neighboring minima.</li>
+    </ul>
+  </section>
+
+  <section data-background-color="#050816" data-transition="fade">
+    <h2>Key takeaways</h2>
+    <ol>
+      <li class="fragment">Treat parameters as geometry to build intuition.</li>
+      <li class="fragment">Structure creates friendly landscapes; noise explores them.</li>
+      <li class="fragment">Generalization lives in wide, connected valleys.</li>
+    </ol>
+  </section>
+
+  <section data-background-color="#03040f" data-transition="fade">
+    <h2>Further reading</h2>
+    <p class="fragment"><a href="https://arxiv.org/abs/1712.09913" target="_blank" rel="noopener">Visualizing the Loss Landscape of Neural Nets</a></p>
+    <p class="fragment"><a href="https://arxiv.org/abs/1906.06762" target="_blank" rel="noopener">Mode Connectivity and the Landscape of Neural Computation</a></p>
+    <p class="fragment"><a href="https://arxiv.org/abs/2205.03201" target="_blank" rel="noopener">Sharpness-Aware Minimization</a></p>
+  </section>
+
+  <section data-background-color="#00040d" data-transition="fade">
+    <h1>Thank you!</h1>
+    <p>Slides written by <strong>GPT-5 Codex</strong>.</p>
+    <p class="fragment">Ping me if you remix these decks or explore new basins.</p>
+  </section>
+</section>
+
+<style>
+  .title-card {
+    background: rgba(3, 8, 30, 0.7);
+    padding: 2rem 3rem;
+    border-radius: 1.5rem;
+    backdrop-filter: blur(6px);
+  }
+  .title-card h1 {
+    margin-bottom: 0.4em;
+  }
+  .title-card h3 {
+    color: #aadaff;
+    font-weight: 400;
+  }
+  .attribution {
+    margin-top: 1.5rem;
+    font-size: 0.9em;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #7ec8ff;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 2rem;
+  }
+  .columns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2rem;
+  }
+  .loop-diagram {
+    width: 80%;
+    max-width: 760px;
+    margin: 1.5rem auto 0 auto;
+    display: block;
+  }
+  .overlay {
+    background: rgba(0, 4, 13, 0.75);
+    padding: 1.5rem 2rem;
+    border-radius: 1rem;
+  }
+  #loss-landscape {
+    background: radial-gradient(circle at center, rgba(20, 80, 180, 0.2), rgba(3, 8, 23, 0.9));
+    border-radius: 1.5rem;
+    box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.35);
+  }
+</style>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var canvas = document.getElementById('loss-landscape');
+    if (!canvas || !canvas.getContext) return;
+
+    var ctx = canvas.getContext('2d');
+    var width = canvas.width;
+    var height = canvas.height;
+    var t = 0;
+
+    function loss(x, y) {
+      return Math.sin(x * 0.8) * Math.cos(y * 0.6) * 0.5 + Math.pow(x * 0.05, 2) + Math.pow(y * 0.05, 2);
+    }
+
+    function drawSurface() {
+      var imgData = ctx.createImageData(width, height);
+      for (var px = 0; px < width; px++) {
+        for (var py = 0; py < height; py++) {
+          var x = (px - width / 2) / 15;
+          var y = (py - height / 2) / 15;
+          var l = loss(x, y);
+          var shade = Math.max(0, Math.min(255, 160 + l * 80));
+          var idx = (py * width + px) * 4;
+          imgData.data[idx] = 40 + l * 60;
+          imgData.data[idx + 1] = shade;
+          imgData.data[idx + 2] = 220 - l * 40;
+          imgData.data[idx + 3] = 255;
+        }
+      }
+      ctx.putImageData(imgData, 0, 0);
+    }
+
+    function drawPath() {
+      var pathLength = 240;
+      ctx.lineWidth = 4;
+      ctx.strokeStyle = 'rgba(255, 214, 102, 0.9)';
+      ctx.beginPath();
+      for (var i = 0; i <= pathLength; i++) {
+        var progress = i / pathLength;
+        var x = Math.cos(progress * Math.PI * 1.5) * 25;
+        var y = Math.sin(progress * Math.PI) * 35;
+        var px = width / 2 + x * 4;
+        var py = height / 2 + y * 4 + Math.sin(progress * Math.PI * 2) * 6;
+        if (i === 0) {
+          ctx.moveTo(px, py);
+        } else {
+          ctx.lineTo(px, py);
+        }
+      }
+      ctx.stroke();
+    }
+
+    function drawMarker(time) {
+      var progress = (Math.sin(time / 1300) + 1) / 2;
+      var x = Math.cos(progress * Math.PI * 1.5) * 25;
+      var y = Math.sin(progress * Math.PI) * 35;
+      var px = width / 2 + x * 4;
+      var py = height / 2 + y * 4 + Math.sin(progress * Math.PI * 2) * 6;
+
+      ctx.fillStyle = '#f25f5c';
+      ctx.strokeStyle = 'rgba(0, 0, 0, 0.3)';
+      ctx.lineWidth = 6;
+      ctx.beginPath();
+      ctx.arc(px, py, 12, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+    }
+
+    function frame(time) {
+      drawSurface();
+      drawPath();
+      drawMarker(time || 0);
+      t += 1;
+      requestAnimationFrame(frame);
+    }
+
+    drawSurface();
+    drawPath();
+    requestAnimationFrame(frame);
+  });
+</script>

--- a/index.html
+++ b/index.html
@@ -39,20 +39,76 @@ bigimg: [/img/futuristic-cityscape-at-night_800.jpg, /img/ai-cover.jpg]
 {% include index_columns.html %}
 
 <div class="alert alert-info presentation-prototype" role="note">
-  <h4>Presentation Template Prototype</h4>
+  <h4>Standardized Reveal.js Presentations</h4>
   <p>
-    We are testing a unified Reveal.js layout. Visit the prototype deck to review the navigation chrome,
-    plugin defaults, and general look &amp; feel before migrating existing talks.
+    All presentations have been migrated to a unified Reveal.js layout with consistent navigation, plugin support,
+    and theme switching capabilities.
   </p>
-  <a class="btn btn-primary btn-sm" href="{{ '/presentations/standardization-prototype/' | relative_url }}">
-    Explore the prototype deck
-  </a>
-  <a class="btn btn-primary btn-sm" href="{{ '/presentations/hanabi-challenge/' | relative_url }}">
-    Hanabi Challenge (New)
-  </a>
-  <a class="btn btn-default btn-sm" href="{{ '/stack/hanabi/hanabichallenge.html' | relative_url }}">
-    Hanabi Challenge (Original)
-  </a>
+  
+  <h5><i class="fa fa-flask"></i> Prototypes &amp; Challenges</h5>
+  <div class="btn-group" role="group" style="margin-bottom: 10px;">
+    <a class="btn btn-primary btn-sm" href="{{ '/presentations/standardization-prototype/' | relative_url }}">
+      <i class="fa fa-rocket"></i> Prototype Deck
+    </a>
+    <a class="btn btn-primary btn-sm" href="{{ '/presentations/hanabi-challenge/' | relative_url }}">
+      <i class="fa fa-gamepad"></i> Hanabi Challenge
+    </a>
+    <a class="btn btn-default btn-sm" href="{{ '/stack/hanabi/hanabichallenge.html' | relative_url }}">
+      <i class="fa fa-archive"></i> Hanabi (Original)
+    </a>
+  </div>
+  
+  <h5><i class="fa fa-graduation-cap"></i> Technical Talks</h5>
+  <div class="btn-group" role="group" style="margin-bottom: 10px;">
+    <a class="btn btn-primary btn-sm" href="{{ '/presentations/eyes-on-bot/' | relative_url }}">
+      <i class="fa fa-eye"></i> Implementando ojos a tu chatbot
+    </a>
+    <a class="btn btn-default btn-sm" href="{{ '/talks/eyes_on_bot.html' | relative_url }}">
+      <i class="fa fa-archive"></i> Original
+    </a>
+  </div>
+  <div class="btn-group" role="group" style="margin-bottom: 10px;">
+    <a class="btn btn-primary btn-sm" href="{{ '/presentations/lessons/' | relative_url }}">
+      <i class="fa fa-lightbulb-o"></i> Lecciones sobre memes
+    </a>
+    <a class="btn btn-default btn-sm" href="{{ '/talks/lessons.html' | relative_url }}">
+      <i class="fa fa-archive"></i> Original
+    </a>
+  </div>
+  <div class="btn-group" role="group" style="margin-bottom: 10px;">
+    <a class="btn btn-primary btn-sm" href="{{ '/presentations/onto-memes/' | relative_url }}">
+      <i class="fa fa-flask"></i> Generación de memes (CoLiCo)
+    </a>
+    <a class="btn btn-default btn-sm" href="{{ '/talks/onto_memes.html' | relative_url }}">
+      <i class="fa fa-archive"></i> Original
+    </a>
+  </div>
+  <div class="btn-group" role="group" style="margin-bottom: 10px;">
+    <a class="btn btn-primary btn-sm" href="{{ '/presentations/thesis/' | relative_url }}">
+      <i class="fa fa-file-text"></i> Thesis Defense
+    </a>
+    <a class="btn btn-default btn-sm" href="{{ '/talks/thesis.html' | relative_url }}">
+      <i class="fa fa-archive"></i> Original
+    </a>
+  </div>
+  
+  <h5><i class="fa fa-university"></i> Course Materials (ML Centraal)</h5>
+  <div class="btn-group" role="group" style="margin-bottom: 10px;">
+    <a class="btn btn-primary btn-sm" href="{{ '/presentations/demoday/' | relative_url }}">
+      <i class="fa fa-bar-chart"></i> Demo Day - IA Era
+    </a>
+    <a class="btn btn-default btn-sm" href="{{ '/course_slides/ml_centraal/demoday.html' | relative_url }}">
+      <i class="fa fa-archive"></i> Original
+    </a>
+  </div>
+  <div class="btn-group" role="group" style="margin-bottom: 10px;">
+    <a class="btn btn-primary btn-sm" href="{{ '/presentations/weight-space-learning/' | relative_url }}">
+      <i class="fa fa-cube"></i> Weight Space Learning
+    </a>
+    <a class="btn btn-default btn-sm" href="{{ '/course_slides/ml_centraal/weight-space-learning.html' | relative_url }}">
+      <i class="fa fa-archive"></i> Original
+    </a>
+  </div>
 </div>
 
 <!-- statement -->


### PR DESCRIPTION
Standardize all Reveal.js presentations to a unified Jekyll layout and update `index.html` with links to both new and original versions.

This migration provides a consistent look, feel, and feature set (e.g., theme switching, chalkboard, math support, navigation) across all presentations, and improves their discoverability and organization on the homepage.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e1b178f-501e-4802-b172-85d4c9027b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e1b178f-501e-4802-b172-85d4c9027b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

